### PR TITLE
implement topic urgency system

### DIFF
--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -357,3 +357,15 @@ topicsAPI.move = async (caller, { tid, cid }) => {
 
 	await categories.onTopicsMoved(cids);
 };
+
+topicsAPI.setUrgency = async function (caller, data) {
+	if (!data || !data.tid || typeof data.urgent !== 'boolean') {
+		throw new Error('[[error:invalid-data]]');
+	}
+	if (!caller.uid) {
+		throw new Error('[[error:not-logged-in]]');
+	}
+
+	const result = await topics.tools.setUrgency(data.tid, data.urgent, caller.uid);
+	return result;
+};

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -35,6 +35,7 @@ module.exports = function (Topics) {
 			lastposttime: 0,
 			postcount: 0,
 			viewcount: 0,
+			urgent: data.urgent || false,
 		};
 
 		if (Array.isArray(data.tags) && data.tags.length) {

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -13,7 +13,7 @@ const intFields = [
 	'viewcount', 'postercount', 'followercount',
 	'deleted', 'locked', 'pinned', 'pinExpiry',
 	'timestamp', 'upvotes', 'downvotes',
-	'lastposttime', 'deleterUid',
+	'lastposttime', 'deleterUid', 'urgent',
 ];
 
 module.exports = function (Topics) {

--- a/vendor/nodebb-theme-harmony-2.1.15/plugin.json
+++ b/vendor/nodebb-theme-harmony-2.1.15/plugin.json
@@ -15,7 +15,8 @@
 	],
 	"modules": {
 		"../admin/plugins/harmony.js": "public/admin.js",
-		"../client/account/theme.js": "public/settings.js"
+		"../client/account/theme.js": "public/settings.js",
+		"composer-urgent.js": "static/lib/composer-urgent.js"
 	},
 	"staticDirs": {
 		"inter": "node_modules/@fontsource/inter/files",


### PR DESCRIPTION
src/api/topics.js: Validates input and login, then sets a topic’s urgency via topics.tools.setUrgency using tid, urgent flag, and caller uid. Returns result.
src/topics/create.js: add urgent field and set to false initially.
src/topics/data.js: add urgent field to the database.
vendor/nodebb-theme-harmony-2.1.15/plugin.json: Exposes a module named composer-urgent.js that loads static/lib/composer-urgent.js



